### PR TITLE
Second part of the defaultTableName field race fix (#2060)

### DIFF
--- a/model_struct.go
+++ b/model_struct.go
@@ -24,11 +24,16 @@ type ModelStruct struct {
 	PrimaryFields    []*StructField
 	StructFields     []*StructField
 	ModelType        reflect.Type
+
 	defaultTableName string
+	l sync.Mutex
 }
 
 // TableName returns model's table name
 func (s *ModelStruct) TableName(db *DB) string {
+	s.l.Lock()
+	defer s.l.Unlock()
+
 	if s.defaultTableName == "" && db != nil && s.ModelType != nil {
 		// Set default table name
 		if tabler, ok := reflect.New(s.ModelType).Interface().(tabler); ok {


### PR DESCRIPTION
* fix (https://github.com/jinzhu/gorm/issues/1407)

* changed map with mutex to sync.Map (https://github.com/jinzhu/gorm/issues/1407)

* removed newModelStructsMap func

* commit to rerun pipeline, comment changed

* fix race with defaultTableName field (again)

Make sure these boxes checked before submitting your pull request.

- [] Do only one thing
- [] No API-breaking changes
- [] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
